### PR TITLE
Update git status to use porcelain

### DIFF
--- a/bin/pyenv-update
+++ b/bin/pyenv-update
@@ -20,7 +20,7 @@ verify_repo_branch() {
 }
 
 verify_repo_clean() {
-  ! ( cd "$1" && git status --short ) | grep -q -v '^[!?][!?]'
+  ! ( cd "$1" && git status --porcelain ) | grep -q -v '^[!?][!?]'
 }
 
 verify_repo() {


### PR DESCRIPTION
pyenv-update was failing for me with the following errors, even though I had no local changes:

```
$ pyenv update
Updating /home/vagrant/.pyenv...
pyenv-update: /home/vagrant/.pyenv is not clean
Updating /home/vagrant/.pyenv/plugins/pyenv-doctor...
pyenv-update: /home/vagrant/.pyenv/plugins/pyenv-doctor is not clean
Updating /home/vagrant/.pyenv/plugins/pyenv-pip-rehash...
pyenv-update: /home/vagrant/.pyenv/plugins/pyenv-pip-rehash is not clean
Updating /home/vagrant/.pyenv/plugins/pyenv-update...
pyenv-update: /home/vagrant/.pyenv/plugins/pyenv-update is not clean
Updating /home/vagrant/.pyenv/plugins/pyenv-virtualenvwrapper...
pyenv-update: /home/vagrant/.pyenv/plugins/pyenv-virtualenvwrapper is not clean
Updating /home/vagrant/.pyenv/plugins/pyenv-which-ext...
pyenv-update: /home/vagrant/.pyenv/plugins/pyenv-which-ext is not clean
```

From the man page:

```
       --porcelain
           Give the output in an easy-to-parse format for scripts. This is similar to the short output, but will remain
           stable across Git versions and regardless of user configuration. See below for details.
```
