### PR TITLE
Ensure update is a fast-forward merge

### DIFF
--- a/bin/pyenv-update
+++ b/bin/pyenv-update
@@ -43,7 +43,7 @@ verify_repo() {
 update_repo() {
   info "Updating $1..."
   verify_repo "$1" &&
-  ( cd "${repo}" && git pull "${REMOTE}" "${BRANCH}" )
+  ( cd "${repo}" && git pull --no-rebase --ff "${REMOTE}" "${BRANCH}" )
 }
 
 info() {


### PR DESCRIPTION
This overrides global git configuration, which may cause `git pull` to rebase by default, and ensures that the update is a fast-forward.
