### PR TITLE
Only use actual branch names when verifying branch

### DIFF
--- a/bin/pyenv-update
+++ b/bin/pyenv-update
@@ -15,7 +15,7 @@ verify_repo_remote() {
 }
 
 verify_repo_branch() {
-  local name="$(cd "$1" && git name-rev --name-only HEAD 2>/dev/null)"
+  local name="$(cd "$1" && git name-rev --refs='heads/*' --name-only HEAD 2>/dev/null)"
   [[ "${name}" == "${BRANCH}" ]]
 }
 


### PR DESCRIPTION
When pyenv-update verifies the current branch name using `git name-rev`, it fails to exclude refs that are not (branch) heads. So if there is, for instance, a version tag present, pyenv-update will detect that and assume that the checked-out version is not on branch `master`, even though it is.

For instance, right now (as I write this), the `v1.2.2` tag is triggering this issue:

    $ pyenv update
    Updating /Users/visagie/.pyenv...
    pyenv-update: /Users/visagie/.pyenv is not on master branch.
    Updating /Users/visagie/.pyenv/plugins/pyenv-alias...
    From https://github.com/s1341/pyenv-alias
     * branch            master     -> FETCH_HEAD
    Already up to date.
    …  [etc.]
