### PR TITLE
Add placeholder for tests on travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: false
+install: git clone https://github.com/sstephenson/bats.git
+script: bats/bin/bats --tap test
+language: c
+notifications:
+  email:
+    on_success: never

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # pyenv-update
 
+[![Build Status](https://travis-ci.org/pyenv/pyenv-update.svg?branch=master)](https://travis-ci.org/pyenv/pyenv-update)
+
 pyenv-update is a [pyenv](https://github.com/pyenv/pyenv) plugin
 that provides a `pyenv update` command to update pyenv and its plugins.
 


### PR DESCRIPTION
We found out in #4 that we're turning on travis-ci.org on this repo but we don't have any tests.