### PR TITLE
older git versions support when verifying branch name

### DIFF
--- a/bin/pyenv-update
+++ b/bin/pyenv-update
@@ -15,7 +15,7 @@ verify_repo_remote() {
 }
 
 verify_repo_branch() {
-  local name="$(cd "$1" && git name-rev --refs='heads/*' --name-only HEAD 2>/dev/null)"
+  local name="$(cd "$1" && git name-rev --refs='refs/heads/*' --name-only HEAD 2>/dev/null)"
   [[ "${name}" == "${BRANCH}" ]]
 }
 


### PR DESCRIPTION
simply use the full ref name.