### PR TITLE
Update install snippet to use pyenv root

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This plugin was inspired from [rbenv-update](https://github.com/rkh/rbenv-update
 Installing pyenv-update as a pyenv plugin will give you access to the
 `pyenv update` command.
 
-    $ git clone git://github.com/pyenv/pyenv-update.git ~/.pyenv/plugins/pyenv-update
+    $ git clone git://github.com/pyenv/pyenv-update.git $(pyenv root)/plugins/pyenv-update
 
 ## Usage
 


### PR DESCRIPTION
This is quite helpful if you're installing Pyenv into a non-standard location, and/or using a helper like Anyenv or similar.