### PR TITLE
Add '--tags' to 'git pull' command to pull in tags for repos as well

### DIFF
--- a/bin/pyenv-update
+++ b/bin/pyenv-update
@@ -54,7 +54,7 @@ verify_repo() {
 update_repo() {
   info "Updating $1..."
   verify_repo "$1" &&
-  ( cd "${repo}" && git pull --no-rebase --ff "${REMOTE}" "${BRANCH_CHOICE}" )
+  ( cd "${repo}" && git pull --tags --no-rebase --ff "${REMOTE}" "${BRANCH_CHOICE}" )
 }
 
 info() {

--- a/bin/pyenv-update
+++ b/bin/pyenv-update
@@ -54,6 +54,7 @@ verify_repo() {
 update_repo() {
   info "Updating $1..."
   verify_repo "$1" &&
+  # pyenv-installer makes the repos shallow, so tags are not fetched by default
   ( cd "${repo}" && git pull --tags --no-rebase --ff "${REMOTE}" "${BRANCH_CHOICE}" )
 }
 


### PR DESCRIPTION
Noticed that tags for pyenv and other plugins weren't being pulled in during the update; this fixes it.