### PR TITLE
README: remove leading $ from copypastable commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,17 @@ This plugin was inspired from [rbenv-update](https://github.com/rkh/rbenv-update
 Installing pyenv-update as a pyenv plugin will give you access to the
 `pyenv update` command.
 
-    $ git clone https://github.com/pyenv/pyenv-update.git $(pyenv root)/plugins/pyenv-update
+```sh
+git clone https://github.com/pyenv/pyenv-update.git $(pyenv root)/plugins/pyenv-update
+```
 
 ## Usage
 
 To update pyenv and plugins (including pyenv-update itself), just type `pyenv update`.
 
-    $ pyenv update
+```sh
+pyenv update
+```
 
 ## Version History
 


### PR DESCRIPTION
This makes it easier to copy+paste commands from the rendered readme on GitHub.